### PR TITLE
docker: set health check and time zone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,29 @@ WORKDIR /app
 RUN cargo auditable build --release
 
 FROM debian:bullseye-slim
-RUN apt update && apt install -y ca-certificates
-RUN mkdir -p /opt/hookd
+
+RUN apt-get update -qq -o Acquire::Languages=none && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install \
+    -yqq \
+# install...
+        ca-certificates \
+        tzdata \
+        curl && \
+# clean up...
+    rm -rf /var/lib/apt/lists/* && \
+# create working directory
+    mkdir -p /opt/hookd && \
+# ensure the UTC timezone is set
+    ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
 WORKDIR /opt/hookd
 COPY --from=builder /app/target/release/hookd /usr/local/bin/hookd
 CMD ["/usr/local/bin/hookd"]
 
+ENV TZ=Etc/UTC
+# This port number should match the number set in `config.sample.yaml`
+ARG service_port_number=9320
+EXPOSE ${service_port_number}/tcp
+ENV SERVICE_PORT=${service_port_number}
+HEALTHCHECK --interval=3s --timeout=3s --retries=2 --start-period=5s \
+ CMD curl -fSs http://localhost:$SERVICE_PORT/health || exit 1

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ cargo install hookd
 
 Create a config file in `~/.config/hookd/config.yaml` based on the `config.sample.yaml` in this repo.
 
+### Healthcheck for Docker container
+The service API implements the `/health` check for the Docker containers.
+
+*IMPORTANT*: In order the Docker container to be able to perform the check, the image MUST provide the `curl` tool. If changing or updating the base image's version, please ensure the `curl` availability!
+
+````BASH
+curl -s http://localhost:9320/health || exit 1
+````
+
+S. [Dockerfile](./Dockerfile) for details.
+
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,4 +1,4 @@
-address: 127.0.0.1:8080
+address: 127.0.0.1:9320
 log_level: warn
 hooks: 
   ls:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -122,7 +122,7 @@ components:
         version: HTTP/1.1
         headers:
           content-type: application/json
-          host: localhost:8080
+          host: localhost:9320
           accept: '*/*'
           user-agent: curl/7.77.0
           content-length: "11"
@@ -196,7 +196,7 @@ components:
           version: HTTP/1.1
           headers:
             content-type: application/json
-            host: localhost:8080
+            host: localhost:9320
             accept: '*/*'
             user-agent: curl/7.77.0
             content-length: "11"


### PR DESCRIPTION
- change default port 8080 to 9320 to match the wfs configuration
- part of https://github.com/famedly/product-management/issues/1679